### PR TITLE
Fix lookup for free shipping component

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Now that you have experience with some of the basics, we work on the homepage. T
             return $('.hero');
         },
         shipping: function() {
-            return $('.header .shipping').text();
+            return $('.free-shipping');
         },
         discountBanner: function() {
             return $('.banner-message');


### PR DESCRIPTION
The markup for the free-shipping banner has changed on the desktop site.
This makes sure the lookup of the content (now an image) still works.
