### PR TITLE
Fix lookup of free shipping content.

### DIFF
--- a/adaptation/views/home.js
+++ b/adaptation/views/home.js
@@ -13,7 +13,7 @@ function($, BaseView, template) {
                 return $('.hero');
             },
             shipping: function() {
-                return $('.header .shipping').text();
+                return $('.free-shipping');
             },
             discountBanner: function() {
                 return $('.banner-message');


### PR DESCRIPTION
The class for the free shipping content has changed to `free-shipping`
and the actual content is not textual anymore but an image. This
corrects the lookup of the element.
