### PR TITLE
change preview url to http://www

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "url": "http://github.com/mobify/merlins-potions-adaptive-2"
     },
     "private": true,
-    "siteUrl": "merlinspotions.com",
+    "siteUrl": "http://www.merlinspotions.com",
     "version": "0.0.1",
     "dependencies": {
         "adaptivejs": "~2.1.0",


### PR DESCRIPTION
Status: **Ready for Review** 
Owner: @ericawright
Reviewers: @stewartyu 
## Changes
- was receiving 'name not resolved' error when trying to preview the site using the generated preview link 
- changed merlin's potions preview url from merlinspotions.com to http://www.merlinspotions.com
## Todos:
- [x] Engineer +1
### Feedback:

_none so far_
## How to Test
- run `grunt preview`
- click preview button
  -should see 'welcome to your adaptive.js site' page 
